### PR TITLE
Fix check-s3-object on multiple matched files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+- [check-s3-object] Fix `no_crit_on_multiple_objects` flag checks against the newest match
+- [check-s3-object] `no_crit_on_multiple_objects` flag default to false
+
 ## [0.0.2] - 2019-01-18
 
 ### Added

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -52,6 +52,14 @@
   version = "v1.16.21"
 
 [[projects]]
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = "UT"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
   digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
@@ -65,6 +73,14 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "c2b33e84"
+
+[[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = "UT"
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:645cabccbb4fa8aab25a956cbcbdf6a6845ca736b2c64e197ca7cbb9d210b939"
@@ -81,6 +97,35 @@
   pruneopts = "UT"
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
   version = "v1.0.3"
+
+[[projects]]
+  digest = "1:ac83cf90d08b63ad5f7e020ef480d319ae890c208f8524622a2f3136e2686b02"
+  name = "github.com/stretchr/objx"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "477a77ecc69700c7cdeb1fa9e129548e1c1c393c"
+  version = "v0.1.1"
+
+[[projects]]
+  digest = "1:7a905394a784c598221920806f290b22b07ac787e1945af762c5c475781084f4"
+  name = "github.com/stretchr/testify"
+  packages = [
+    ".",
+    "assert",
+    "http",
+    "mock",
+  ]
+  pruneopts = "UT"
+  revision = "221dbe5ed46703ee255b1da0dec05086f5035f62"
+  version = "v1.4.0"
+
+[[projects]]
+  digest = "1:1033856ca84153217fda9f527e1c02e11b636e28ad2ab19f2ea4a06e4abbe8e1"
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "bb4e33bf68bf89cad44d386192cbed201f35b241"
+  version = "v2.2.3"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -99,6 +144,8 @@
     "github.com/aws/aws-sdk-go/service/s3",
     "github.com/aws/aws-sdk-go/service/sts",
     "github.com/spf13/cobra",
+    "github.com/stretchr/testify",
+    "github.com/stretchr/testify/assert",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,3 +36,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "github.com/stretchr/testify"
+  version = "1.4.0"

--- a/plugins/s3/check-s3-object/main.go
+++ b/plugins/s3/check-s3-object/main.go
@@ -88,7 +88,7 @@ func checkObject() {
 			age = time.Since(*output.LastModified)
 			size = *output.ContentLength
 			keyFullName = keyName
-			printMesaage(age, keyFullName, size)
+			printMessage(age, keyFullName, size)
 		}
 	} else if len(strings.TrimSpace(keyPrefix)) > 0 {
 		input := &s3.ListObjectsInput{Bucket: aws.String(bucketName), Prefix: aws.String(keyPrefix)}
@@ -113,17 +113,17 @@ func checkObject() {
 		keyFullName = *output.Contents[0].Key
 		age = time.Since(*output.Contents[0].LastModified)
 		size = *output.Contents[0].Size
-		printMesaage(age, keyFullName, size)
+		printMessage(age, keyFullName, size)
 	}
 }
 
 func checkAge(age time.Duration, keyName string) {
 	if age.Seconds() > criticalAge {
-		fmt.Println(fmt.Sprintf("CRITICAL : S3 Object '%s' size : '%d' octets (Bucket - '%s')", keyName, age, bucketName))
+		fmt.Println(fmt.Sprintf("CRITICAL : S3 Object '%s' age : '%d' octets (Bucket - '%s')", keyName, int(age.Seconds()), bucketName))
 		return
 	}
 	if age.Seconds() > warningAge {
-		fmt.Println(fmt.Sprintf("WARNING : S3 Object '%s' size : '%d' octets (Bucket - '%s')", keyName, age, bucketName))
+		fmt.Println(fmt.Sprintf("WARNING : S3 Object '%s' age : '%d' octets (Bucket - '%s')", keyName, int(age.Seconds()), bucketName))
 		return
 	}
 	fmt.Println(fmt.Sprintf("OK : S3 Object '%s' exists in bucket '%s'", keyName, bucketName))
@@ -175,7 +175,7 @@ func printErroMessage(err error, keyFullName string) {
 	}
 }
 
-func printMesaage(age time.Duration, keyFullName string, size int64) {
+func printMessage(age time.Duration, keyFullName string, size int64) {
 	checkAge(age, keyFullName)
 	if size != 0 {
 		checkSize(size, keyFullName)
@@ -248,7 +248,7 @@ func configureRootCommand() *cobra.Command {
 	cmd.Flags().BoolVarP(&noCritOnMultipleObjects,
 		"no_crit_on_multiple_objects",
 		"",
-		true,
+		false,
 		"If this flag is set, sort all matching objects by last_modified date and check against the newest. By default, this check will return a CRITICAL result if multiple matching objects are found.")
 	_ = cmd.MarkFlagRequired("bucket_name")
 	return cmd

--- a/utils/sort.go
+++ b/utils/sort.go
@@ -10,7 +10,7 @@ func SortContents(contents []*s3.Object) {
 	for !sorted {
 		swapped := false
 		for i := 0; i < n-1; i++ {
-			if (*contents[i].LastModified).After(*contents[i+1].LastModified) {
+			if (*contents[i].LastModified).Before(*contents[i+1].LastModified) {
 				contents[i+1], contents[i] = contents[i], contents[i+1]
 				swapped = true
 			}

--- a/utils/sort_test.go
+++ b/utils/sort_test.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestSortContents(t *testing.T) {
+	contents := []*s3.Object{
+		&s3.Object{Key: aws.String("foo_2019-Oct-01"), LastModified: aws.Time(time.Date(2019, 10, 1, 0, 0, 0, 0, time.UTC))},
+		&s3.Object{Key: aws.String("foo_2019-Oct-02"), LastModified: aws.Time(time.Date(2019, 10, 2, 0, 0, 0, 0, time.UTC))},
+		&s3.Object{Key: aws.String("foo_2019-Oct-03"), LastModified: aws.Time(time.Date(2019, 10, 3, 0, 0, 0, 0, time.UTC))},
+	}
+
+	SortContents(contents)
+
+	assert.Equal(t, "foo_2019-Oct-03", aws.StringValue(contents[0].Key))
+	assert.Equal(t, "foo_2019-Oct-02", aws.StringValue(contents[1].Key))
+	assert.Equal(t, "foo_2019-Oct-01", aws.StringValue(contents[2].Key))
+}


### PR DESCRIPTION
Actually `--no_crit_on_multiple_objects` flag will do the check on the oldest s3 object. 

This PR introduce testing and fix S3 utility sort method.