### PR TITLE
Pin goreleaser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.10.x
+- 1.12.x
 install:
 - go get gopkg.in/alecthomas/gometalinter.v1
 - go get github.com/gordonklaus/ineffassign

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,26 @@ language: go
 go:
 - 1.12.x
 install:
-- curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
+- go get gopkg.in/alecthomas/gometalinter.v1
+- go get github.com/gordonklaus/ineffassign
+- go get github.com/jgautheron/goconst/cmd/goconst
+- go get github.com/kisielk/errcheck
 - go get github.com/golang/dep/cmd/dep
 - dep ensure
 script:
-- golangci-lint run --disable-all --enable=vet --enable=ineffassign --enable=goconst --tests ./...
-- go test -v -race ./...
+- gometalinter.v1 --vendor --disable-all --enable=vet --enable=ineffassign
+  --enable=goconst --tests ./...
 
 before_script:
 - echo "REPO $TRAVIS_REPO_SLUG TAG ${TRAVIS_TAG}"
 
+before_deploy:
+- go get github.com/goreleaser/goreleaser
+
 deploy:
   - #goreleaser
     provider: script
-    script: curl -sL https://git.io/goreleaser | bash
+    script: goreleaser
     skip_cleanup: true
     on:
       tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,26 +2,20 @@ language: go
 go:
 - 1.12.x
 install:
-- go get gopkg.in/alecthomas/gometalinter.v1
-- go get github.com/gordonklaus/ineffassign
-- go get github.com/jgautheron/goconst/cmd/goconst
-- go get github.com/kisielk/errcheck
+- curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
 - go get github.com/golang/dep/cmd/dep
 - dep ensure
 script:
-- gometalinter.v1 --vendor --disable-all --enable=vet --enable=ineffassign
-  --enable=goconst --tests ./...
+- golangci-lint run --disable-all --enable=vet --enable=ineffassign --enable=goconst --tests ./...
+- go test -v -race ./...
 
 before_script:
 - echo "REPO $TRAVIS_REPO_SLUG TAG ${TRAVIS_TAG}"
 
-before_deploy:
-- go get github.com/goreleaser/goreleaser
-
 deploy:
   - #goreleaser
     provider: script
-    script: goreleaser
+    script: curl -sL https://git.io/goreleaser | bash
     skip_cleanup: true
     on:
       tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.12.x
+- 1.10.x
 install:
 - go get gopkg.in/alecthomas/gometalinter.v1
 - go get github.com/gordonklaus/ineffassign
@@ -16,7 +16,7 @@ before_script:
 - echo "REPO $TRAVIS_REPO_SLUG TAG ${TRAVIS_TAG}"
 
 before_deploy:
-- go get github.com/goreleaser/goreleaser
+- go get github.com/goreleaser/goreleaser@v0.123.2
 
 deploy:
   - #goreleaser


### PR DESCRIPTION
This should fix the release failing per https://github.com/Codewars/codewars.com/issues/1861#issuecomment-507417558. That is `Replaceall` was added in Go 1.12, which is what goreleaser seems to rely on.