### PR TITLE
Fix: check-rds start time fix for time range for cloudwatch metrics

### DIFF
--- a/plugins/rds/check-rds/main.go
+++ b/plugins/rds/check-rds/main.go
@@ -58,8 +58,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/sensu/sensu-aws/awsclient"
+	"github.com/spf13/cobra"
 
 	"github.com/aws/aws-sdk-go/aws"
 
@@ -173,7 +173,7 @@ func getCloudWatchMetrics(metricname string, rdsName string, unit string) (*floa
 	dimensionFilter.Value = aws.String(rdsName)
 	input.Dimensions = []*cloudwatch.Dimension{&dimensionFilter}
 	input.EndTime = aws.Time(time.Now())
-	input.StartTime = aws.Time((input.EndTime).Add(time.Duration(-period/60) * time.Minute))
+	input.StartTime = aws.Time((input.EndTime).Add(time.Duration(-fetchAge/60) * time.Minute))
 	input.Period = aws.Int64(period)
 	input.Statistics = []*string{aws.String(strings.Title(statistic))}
 	input.Unit = aws.String(unit)


### PR DESCRIPTION
using fetch age for calculating duration/time range for cloudwatch metrics.
In previous implementation it was calculated on the basis of the period, also period is defined in the input.
so, the data point returned list will always be 1.
for example, in time range 1 min, return all data points with period 1 min. value always will be 1.

Above lead to condition of faliure of condition len(metrics.Datapoints) > 1 at line 184.
issue id: https://github.com/sensu/sensu-aws/issues/3